### PR TITLE
[ADD] ssi_bad_debt_allowance_operating_unit

### DIFF
--- a/setup/ssi_bad_debt_allowance_operating_unit/odoo/addons/ssi_bad_debt_allowance_operating_unit
+++ b/setup/ssi_bad_debt_allowance_operating_unit/odoo/addons/ssi_bad_debt_allowance_operating_unit
@@ -1,0 +1,1 @@
+../../../../ssi_bad_debt_allowance_operating_unit

--- a/setup/ssi_bad_debt_allowance_operating_unit/setup.py
+++ b/setup/ssi_bad_debt_allowance_operating_unit/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/ssi_bad_debt_allowance_operating_unit/README.rst
+++ b/ssi_bad_debt_allowance_operating_unit/README.rst
@@ -1,0 +1,39 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================================
+Bad Debt Allowance + Operating Unit
+===================================
+
+Glue module that adds Operating Unit support to the Bad Debt Allowance
+module. Extends ``bad_debt_allowance`` with ``mixin.single_operating_unit``,
+so bad debt allowance documents can be scoped and restricted per operating
+unit.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/open-synergy/ssi-bad-debt/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andhitia Rama <andhitia.r@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://simetri-sinergi.id/logo.png
+   :alt: PT. Simetri Sinergi Indonesia
+   :target: https://simetri-sinergi.id
+
+This module is maintained by the PT. Simetri Sinergi Indonesia.

--- a/ssi_bad_debt_allowance_operating_unit/__init__.py
+++ b/ssi_bad_debt_allowance_operating_unit/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/ssi_bad_debt_allowance_operating_unit/__manifest__.py
+++ b/ssi_bad_debt_allowance_operating_unit/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Bad Debt Allowance + Operating Unit",
+    "version": "14.0.1.0.0",
+    "website": "https://simetri-sinergi.id",
+    "author": "OpenSynergy Indonesia, PT. Simetri Sinergi Indonesia",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "ssi_bad_debt_allowance",
+        "ssi_operating_unit_mixin",
+    ],
+    "data": [
+        "security/res_group/bad_debt_allowance.xml",
+        "security/ir_rule/bad_debt_allowance.xml",
+        "view/bad_debt_allowance.xml",
+    ],
+}

--- a/ssi_bad_debt_allowance_operating_unit/models/__init__.py
+++ b/ssi_bad_debt_allowance_operating_unit/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import bad_debt_allowance

--- a/ssi_bad_debt_allowance_operating_unit/models/bad_debt_allowance.py
+++ b/ssi_bad_debt_allowance_operating_unit/models/bad_debt_allowance.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class BadDebtAllowance(models.Model):  # pylint: disable=too-few-public-methods
+    _name = "bad_debt_allowance"
+    _inherit = [
+        "bad_debt_allowance",
+        "mixin.single_operating_unit",
+    ]

--- a/ssi_bad_debt_allowance_operating_unit/security/ir_rule/bad_debt_allowance.xml
+++ b/ssi_bad_debt_allowance_operating_unit/security/ir_rule/bad_debt_allowance.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="bad_debt_allowance_rule_ou" model="ir.rule">
+    <field name="name">Bad Debt Allowance - Responsible to operating unit data</field>
+    <field name="model_id" ref="ssi_bad_debt_allowance.model_bad_debt_allowance" />
+    <field name="groups" eval="[(4, ref('bad_debt_allowance_ou_group'))]" />
+    <field
+            name="domain_force"
+        >[('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+    <field name="perm_unlink" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+</record>
+</odoo>

--- a/ssi_bad_debt_allowance_operating_unit/security/res_group/bad_debt_allowance.xml
+++ b/ssi_bad_debt_allowance_operating_unit/security/res_group/bad_debt_allowance.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="bad_debt_allowance_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_bad_debt_allowance.bad_debt_allowance_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_bad_debt_allowance.bad_debt_allowance_company_group" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('bad_debt_allowance_ou_group'))]" />
+</record>
+</odoo>

--- a/ssi_bad_debt_allowance_operating_unit/tests/__init__.py
+++ b/ssi_bad_debt_allowance_operating_unit/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_ssi_bad_debt_allowance_operating_unit

--- a/ssi_bad_debt_allowance_operating_unit/tests/test_data_ssi_bad_debt_allowance_operating_unit.yaml
+++ b/ssi_bad_debt_allowance_operating_unit/tests/test_data_ssi_bad_debt_allowance_operating_unit.yaml
@@ -1,0 +1,90 @@
+scenarios:
+  - name: "Bad Debt Allowance - Operating Unit propagation"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Test Bad Debt Allowance OU Partner 1"
+          is_company: true
+
+      - step: "Create bad_debt_allowance with operating_unit_id"
+        action: "create"
+        model: "bad_debt_allowance"
+        save_as: "allowance"
+        values:
+          date: "2024-01-15"
+          partner_id: "REC: partner.id"
+          type_id: "REF: ssi_bad_debt_allowance.demo_allowance_type"
+          journal_id: "REF: ssi_bad_debt_allowance.demo_allowance_journal"
+          allowance_account_id: "REF: ssi_bad_debt_allowance.demo_allowance_account"
+          expense_account_id: "REF: ssi_bad_debt_allowance.demo_expense_account"
+          operating_unit_id: "REF: operating_unit.main_operating_unit"
+
+      - step: "Assert bad_debt_allowance operating_unit_id is set"
+        action: "assert"
+        target: "allowance"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Bad Debt Allowance - ir.rule restricts access by operating unit"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Test Bad Debt Allowance OU Partner 2"
+          is_company: true
+
+      - step: "Create bad_debt_allowance with main operating unit"
+        action: "create"
+        model: "bad_debt_allowance"
+        save_as: "allowance"
+        values:
+          date: "2024-01-15"
+          partner_id: "REC: partner.id"
+          type_id: "REF: ssi_bad_debt_allowance.demo_allowance_type"
+          journal_id: "REF: ssi_bad_debt_allowance.demo_allowance_journal"
+          allowance_account_id: "REF: ssi_bad_debt_allowance.demo_allowance_account"
+          expense_account_id: "REF: ssi_bad_debt_allowance.demo_expense_account"
+          operating_unit_id: "REF: operating_unit.main_operating_unit"
+
+      - step: "Create user restricted to a different operating unit"
+        action: "create"
+        model: "res.users"
+        save_as: "restricted_user"
+        values:
+          name: "Restricted OU User"
+          login: "restricted_bad_debt_ou_user@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: ssi_bad_debt_allowance.bad_debt_allowance_user_group"
+                - "REF:
+                  ssi_bad_debt_allowance_operating_unit.bad_debt_allowance_ou_group"
+          assigned_operating_unit_ids:
+            - - 6
+              - 0
+              - - "REF: operating_unit.b2b_operating_unit"
+
+      - step: "Restricted user cannot see the record"
+        action: "search"
+        model: "bad_debt_allowance"
+        domain: [["id", "=", "REC: allowance.id"]]
+        save_as: "search_result"
+        as_user: "restricted_user"
+        expect_count: 0
+
+      - step: "Restricted user cannot write the record"
+        action: "write"
+        target: "allowance"
+        as_user: "restricted_user"
+        expect_error:
+          type: "AccessError"
+        values:
+          date: "2024-02-01"

--- a/ssi_bad_debt_allowance_operating_unit/tests/test_ssi_bad_debt_allowance_operating_unit.py
+++ b/ssi_bad_debt_allowance_operating_unit/tests/test_ssi_bad_debt_allowance_operating_unit.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSsiBadDebtAllowanceOperatingUnit(YamlTransactionCase):
+    def test_ssi_bad_debt_allowance_operating_unit(self):
+        self.run_yaml_scenario("test_data_ssi_bad_debt_allowance_operating_unit.yaml")

--- a/ssi_bad_debt_allowance_operating_unit/view/bad_debt_allowance.xml
+++ b/ssi_bad_debt_allowance_operating_unit/view/bad_debt_allowance.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<!-- TREE VIEW -->
+<record id="bad_debt_allowance_view_tree" model="ir.ui.view">
+    <field name="name">bad_debt_allowance tree</field>
+    <field name="model">bad_debt_allowance</field>
+    <field
+            name="inherit_id"
+            ref="ssi_bad_debt_allowance.bad_debt_allowance_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<!-- SEARCH VIEW -->
+<record id="bad_debt_allowance_view_search" model="ir.ui.view">
+    <field name="name">bad_debt_allowance search</field>
+    <field name="model">bad_debt_allowance</field>
+    <field
+            name="inherit_id"
+            ref="ssi_bad_debt_allowance.bad_debt_allowance_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='grp_company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by':'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<!-- FORM VIEW -->
+<record id="bad_debt_allowance_view_form" model="ir.ui.view">
+    <field name="name">bad_debt_allowance form</field>
+    <field name="model">bad_debt_allowance</field>
+    <field
+            name="inherit_id"
+            ref="ssi_bad_debt_allowance.bad_debt_allowance_view_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
## Summary

Modul glue baru `ssi_bad_debt_allowance_operating_unit` yang menambahkan integrasi Operating Unit pada `bad_debt_allowance`:

* Field `operating_unit_id` via `mixin.single_operating_unit`
* Security: `res.groups` (implied oleh grup Company existing) + `ir.rule` pembatas akses per operating unit
* View: field `operating_unit_id` di tree/form/search (setelah `company_id`) + filter group-by `grp_ou` setelah `grp_company`
* Unit test (odoo-yaml-test): propagasi `operating_unit_id` + pembatasan akses `ir.rule` untuk user tanpa akses OU terkait

Ref: BL-0251

## Test plan

- [ ] CI hijau (lint + unit test)